### PR TITLE
Added source:Unload(), .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/build/
+*.3dsx
+*.smdh
+*.cia
+*.elf
+*.3ds

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,10 @@
 /build/
+/source/libs/libsf2d/lib/
+/source/libs/libsf2d/build/
+/source/libs/libsftd/lib/
+/source/libs/libsftd/build/
+/source/libs/libsfil/lib/
+/source/libs/libsfil/build/
 *.3dsx
 *.smdh
 *.cia

--- a/source/objects/source.c
+++ b/source/objects/source.c
@@ -229,6 +229,28 @@ int sourceGC(lua_State *L) { // Garbage Collection
 
 }
 
+int sourceUnload(lua_State *L) { // source:Unload(). Stops the sound and frees up memory.
+
+	love_source *self = luaobj_checkudata(L, 1, CLASS_TYPE);
+	
+    CSND_SetPlayState(self->channel, false);
+	CSND_UpdateInfo(0);
+
+	if (self->buffer != NULL) {
+		GSPGPU_FlushDataCache(self->buffer, self->size - 44);
+	    linearFree(self->buffer);
+		
+		channelList[self->channel] = false;
+	} else {
+		return 0;
+    }
+    
+    CSND_UpdateInfo(0);
+
+	return 0;
+
+}
+
 int initSourceClass(lua_State *L) {
 
 	luaL_Reg reg[] = {
@@ -238,6 +260,7 @@ int initSourceClass(lua_State *L) {
 		{"stop",		sourceStop	},
 		{"isPlaying",	sourceIsPlaying},
 		{"setLooping",	sourceSetLooping},
+		{"unload",	    sourceUnload},
 		{ 0, 0 },
 	};
 

--- a/source/objects/source.c
+++ b/source/objects/source.c
@@ -217,21 +217,6 @@ int sourceIsLooping(lua_State *L) { // source:isLooping()
 int sourceGC(lua_State *L) { // Garbage Collection
 
 	love_source *self = luaobj_checkudata(L, 1, CLASS_TYPE);
-
-	if (!self->buffer) return 0;
-
-	linearFree(self->buffer);
-	self->buffer = NULL;
-
-	channelList[self->channel - 8] = false;
-
-	return 0;
-
-}
-
-int sourceUnload(lua_State *L) { // source:Unload(). Stops the sound and frees up memory.
-
-	love_source *self = luaobj_checkudata(L, 1, CLASS_TYPE);
 	
     CSND_SetPlayState(self->channel, false);
 	CSND_UpdateInfo(0);
@@ -260,7 +245,6 @@ int initSourceClass(lua_State *L) {
 		{"stop",		sourceStop	},
 		{"isPlaying",	sourceIsPlaying},
 		{"setLooping",	sourceSetLooping},
-		{"unload",	    sourceUnload},
 		{ 0, 0 },
 	};
 


### PR DESCRIPTION
source:Unload() is useful when you need to get rid of a big file (like BGMs) to free up memory. It also stops the audio before wiping it from memory. I haven't tested it with .raw files, but I guess it will only work on .wav files due to the 44 bytes less.

I'm not sure if it'll work if you put it on garbagecollect. It was my idea initially but I only got it to work if you unload it manually.