### PR TITLE
Workaround deltaTime bug

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -97,6 +97,8 @@ int main() {
 	} else {
 		if (luaL_dobuffer(L, nogame_lua, nogame_lua_size, "nogame")) displayError();
 	}
+	
+	if (luaL_dostring(L, "love.timer.step()")) displayError();
 
 	if (luaL_dostring(L, "if love.load then love.load() end")) displayError();
 


### PR DESCRIPTION
Calling `love.timer.step()` upon initialization properly sets up the delta time for the second call. This fixes #56